### PR TITLE
checkプラグインのaction属性に対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,6 @@ __pycache__/
 tests/roles
 *.pyc
 
-# End of https://www.gitignore.io/api/ansible
-
-# Created by https://www.gitignore.io/api/vagrant
-
 ### Vagrant ###
 .vagrant/
 *.box

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mackerel_agent_cfg:
 
 ### mackerel_agent_install_agent_plugins
 
-この変数に`true`が設定されている場合、  
+この変数に`yes`が設定されている場合、  
 mackerel-agent-pluginsのインストールを行います。
 
 ```yml
@@ -67,7 +67,7 @@ mackerel_agent_install_check_plugins: no
 
 ### mackerel_agent_install_check_plugins
 
-この変数に`true`が設定されている場合、  
+この変数に`yes`が設定されている場合、  
 mackerel-check-pluginsのインストールを行います。
 
 ```yml
@@ -78,10 +78,10 @@ mackerel_agent_install_check_plugins: no
 
 mackerel-agentを起動させるかどうかを指定します。
 
-この変数に`true`が設定されている場合、
+この変数に`yes`が設定されている場合、
 mackerel-agentを有効に設定し起動させます。
 
-この変数に`false`が設定されている場合、
+この変数に`no`が設定されている場合、
 mackerel-agentを無効に設定し停止させます。
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ mackerel_agent_install_check_plugins: no
 この変数に`true`が設定されている場合、  
 mackerel-check-pluginsのインストールを行います。
 
-#### Example
-
 ```yml
 mackerel_agent_install_check_plugins: no
 ```
@@ -86,12 +84,9 @@ mackerel-agentを有効に設定し起動させます。
 この変数に`false`が設定されている場合、
 mackerel-agentを無効に設定し停止させます。
 
-#### Example
-
 ```yml
 mackerel_agent_active_and_enabled_on_system_startup: yes
 ```
-
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -6,24 +6,13 @@ mackerel-agentのインストールとセットアップを行います。
 Role Variables
 --------------
 
-| 変数名                                              | 内容                                                       |
-| --------------------------------------------------- | ---------------------------------------------------------- |
-| mackerel_agent_api_key                              | mackerel-agentのAPIキーを設定します                        |
-| mackerel_agent_cfg                                  | その他のmackerel-agentの設定を定義します                   |
-| mackerel_agent_install_agent_plugins                | mackerel-agent-pluginsをインストールするか否かを設定します |
-| mackerel_agent_install_check_plugins                | mackerel-check-pluginsをインストールするか否かを設定します |
-| mackerel_agent_active_and_enabled_on_system_startup | mackerel-agentをサービスの状態を設定します                 |
-
-
 ### mackerel_agent_api_key
 
-mackerel-agentのAPIキーを設定します。
+mackerel-agentのAPIキーを指定します。
 
 ### mackerel_agent_cfg
 
-mackerel-agentの設定を定義します。
-
-#### Example
+mackerel-agentの設定を指定します。
 
 ```yml
 mackerel_agent_cfg:
@@ -43,11 +32,28 @@ mackerel_agent_cfg:
     use_mountpoint: yes
   plugin:
     metrics:
-      apache2: mackerel-plugin-apache2
+      apache2: /usr/bin/mackerel-plugin-apache2
+      mailq: /usr/bin/mackerel-plugin-mailq -M postfix
     checkes:
-      log: "/path/to/check-log --file=/path/to/file --pattern=REGEXP --warning-over=N --critical-over=N"
+      log: "/usr/bin/check-log --file=/path/to/file --pattern=REGEXP --warning-over=N --critical-over=N"
       procs:
-        command: "/path/to/check-procs --pattern=PROCESS_NAME --state=STATE --warning-under=N"
+        command: "/usr/bin/check-procs --pattern=PROCESS_NAME --state=STATE --warning-under=N"
+      load_average:
+        command: "/usr/bin/check-load -w 3,2,1 -c 3,2,1"
+        # optional
+        notification_interval: 60
+        max_check_attempts: 1
+        check_interval: 5
+        timeout_seconds: 45
+        prevent_alert_auto_close: yes
+        memo: "メモをここに記載することができます"
+        env:
+          ENV_NAME: value
+        action:
+          command: "pa -auxf"
+          env:
+            ENV_NAME: value
+          user: "mackerel"
 ```
 
 ### mackerel_agent_install_agent_plugins
@@ -55,15 +61,13 @@ mackerel_agent_cfg:
 この変数に`true`が設定されている場合、  
 mackerel-agent-pluginsのインストールを行います。
 
-#### Example
-
 ```yml
 mackerel_agent_install_check_plugins: no
 ```
 
 ### mackerel_agent_install_check_plugins
 
-この変数に`true`が設定されている場合、
+この変数に`true`が設定されている場合、  
 mackerel-check-pluginsのインストールを行います。
 
 #### Example
@@ -74,7 +78,7 @@ mackerel_agent_install_check_plugins: no
 
 ### mackerel_agent_active_and_enabled_on_system_startup
 
-mackerel-agentを起動させるかどうかを設定します。
+mackerel-agentを起動させるかどうかを指定します。
 
 この変数に`true`が設定されている場合、
 mackerel-agentを有効に設定し起動させます。
@@ -95,7 +99,7 @@ Example Playbook
 ```yml
 - hosts: servers
   roles:
-     - { role: mackerel-agent }
+    - role: mackerel-agent
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 mackerel_agent_api_key: ""
+
 mackerel_agent_cfg: []
   # pidfile: /var/run/mackerel-agent.pid
   # root: /var/lib/mackerel-agent
@@ -17,11 +18,29 @@ mackerel_agent_cfg: []
   #   use_mountpoint: yes
   # plugin:
   #   metrics:
-  #     apache2: mackerel-plugin-apache2
-  #   checkes:
-  #     log: "/path/to/check-log --file=/path/to/file --pattern=REGEXP --warning-over=N --critical-over=N"
+  #     apache2: /usr/bin/mackerel-plugin-apache2
+  #     mailq: /usr/bin/mackerel-plugin-mailq -M postfix
+  #   checks:
+  #     log: "/usr/bin/check-log --file=/path/to/file --pattern=REGEXP --warning-over=N --critical-over=N"
   #     procs:
-  #       command: "/path/to/check-procs --pattern=PROCESS_NAME --state=STATE --warning-under=N"
+  #       command: "/usr/bin/check-procs --pattern=PROCESS_NAME --state=STATE --warning-under=N"
+  #     load_average:
+  #       command: "/usr/bin/check-load -w 3,2,1 -c 3,2,1"
+  #       # optional
+  #       notification_interval: 60
+  #       max_check_attempts: 1
+  #       check_interval: 5
+  #       timeout_seconds: 45
+  #       prevent_alert_auto_close: yes
+  #       memo: "メモをここに記載することができます"
+  #       env:
+  #         ENV_NAME: value
+  #       action:
+  #         command: "pa -auxf"
+  #         env:
+  #           ENV_NAME: value
+  #         user: "mackerel"
+  # extra_setting: ""
 
 mackerel_agent_install_agent_plugins: no
 mackerel_agent_install_check_plugins: no

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,14 +1,57 @@
 ---
 ansible:
   group_vars:
-    default:
+    all:
+      mackerel_agent_cfg:
+        pidfile: /var/run/mackerel-agent.pid
+        root: /var/lib/mackerel-agent
+        verbose: no
+        display_name: My Host
+        http_proxy: http://localhost:8080
+        roles:
+          - My-Service:app
+          - Another-Service:db
+        host_status:
+          on_start: working
+          on_stop: poweroff
+        filesystems:
+          ignore: /dev/ram.*
+          use_mountpoint: yes
+        plugin:
+          metrics:
+            apache2: /usr/bin/mackerel-plugin-apache2
+            mailq: /usr/bin/mackerel-plugin-mailq -M postfix
+          checks:
+            log: "/usr/bin/check-log --file=/path/to/file --pattern=REGEXP --warning-over=N --critical-over=N"
+            procs:
+              command: "/usr/bin/check-procs --pattern=PROCESS_NAME --state=STATE --warning-under=N"
+            load_average:
+              command: "/usr/bin/check-load -w 3,2,1 -c 3,2,1"
+              # optional
+              notification_interval: 60
+              max_check_attempts: 1
+              check_interval: 5
+              timeout_seconds: 45
+              prevent_alert_auto_close: yes
+              memo: '「"(ダブルクォート)」や「\(バックスラッシュ)」は自動でエスケープされます'
+              env:
+                ENV_NAME1: value1
+                ENV_NAME2: value2
+              action:
+                command: pa -auxf
+                env:
+                  ENV_NAME1: value1
+                  ENV_NAME2: value2
+                user: mackerel
+  host_vars:
+    mackerel-agent:
       mackerel_agent_api_key: "{{ lookup('env', 'MACKEREL_API_KEY') }}"
-    enable_all:
+    enable-all:
       mackerel_agent_api_key: "{{ lookup('env', 'MACKEREL_API_KEY') }}"
       mackerel_agent_install_agent_plugins: yes
       mackerel_agent_install_check_plugins: yes
       mackerel_agent_active_and_enabled_on_system_startup: yes
-    disable_all:
+    disable-all:
       mackerel_agent_api_key: "disable_all_api_key"
       mackerel_agent_install_agent_plugins: no
       mackerel_agent_install_check_plugins: no
@@ -30,12 +73,12 @@ vagrant:
   instances:
     - name: mackerel-agent
       ansible_groups:
-        - default
+        - molecule
     - name: enable-all
       ansible_groups:
-        - enable_all
+        - molecule
     - name: disable-all
       ansible_groups:
-        - disable_all
+        - molecule
 verifier:
   name: serverspec

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,3 +2,19 @@
 - hosts: all
   roles:
     - role: mackerel-agent
+  pre_tasks:
+    - name: dump vars
+      block:
+        - name: create dump directory
+          file:
+            path: .molecule/facts
+            state: directory
+          changed_when: no
+        - name: dump host gether facts
+          blockinfile:
+            path: ".molecule/facts/{{ inventory_hostname }}.yml"
+            create: yes
+            block: "{{ vars | to_nice_yaml }}"
+          changed_when: no
+      connection: local
+      become: no

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -13,6 +13,7 @@ end
 describe file('/etc/mackerel-agent/mackerel-agent.conf') do
   it { should exist }
   it { should be_file }
+  it { should be_mode 600 }
   its(:content) { should match(/^apikey = "#{e(property['mackerel_agent_api_key'])}"$/) }
   mackerel_cfg = property['mackerel_agent_cfg']
   mackerel_cfg = property['mackerel_agent_cfg'].to_h if property['mackerel_agent_cfg'].is_a?(Array)

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -16,49 +16,49 @@ describe file('/etc/mackerel-agent/mackerel-agent.conf') do
   its(:content) { should match(/^apikey = "#{e(property['mackerel_agent_api_key'])}"$/) }
   mackerel_cfg = property['mackerel_agent_cfg']
   mackerel_cfg = property['mackerel_agent_cfg'].to_h if property['mackerel_agent_cfg'].is_a?(Array)
-  its(:content) { should match(/^pidfile = "#{e(mackerel_cfg['pidfile'])}"$/) } if mackerel_cfg.key?('pidfile')
-  its(:content) { should match(/^root = "#{e(mackerel_cfg['root'])}"$/) } if mackerel_cfg.key?('root')
+  it { should contain "pidfile = \"#{e(mackerel_cfg['pidfile'])}\"" } if mackerel_cfg.key?('pidfile')
+  it { should contain "root = \"#{e(mackerel_cfg['root'])}\"" } if mackerel_cfg.key?('root')
+
   if mackerel_cfg.key?('verbose')
     verbose = mackerel_cfg['verbose'] ? 'true' : 'false'
-    its(:content) { should match(/^verbose = #{verbose}$/) }
+    it { should contain "verbose = #{verbose}" }
   end
-  if mackerel_cfg.key?('display_name')
-    its(:content) { should match(/^display_name = "#{e(mackerel_cfg['display_name'])}"$/) }
-  end
-  its(:content) { should match(/^http_proxy = "#{e(mackerel_cfg['http_proxy'])}"$/) } if mackerel_cfg.key?('http_proxy')
-  its(:content) { should match(/^roles = \[ "#{mackerel_cfg.join('","')}" \]$/) } if mackerel_cfg.key?('roles')
+
+  it { should contain "display_name = \"#{e(mackerel_cfg['display_name'])}\"" } if mackerel_cfg.key?('display_name')
+  it { should contain "http_proxy = \"#{e(mackerel_cfg['http_proxy'])}\"" } if mackerel_cfg.key?('http_proxy')
+  it { should contain "roles = [ \"#{mackerel_cfg['roles'].join('", "')}\" ]" } if mackerel_cfg.key?('roles')
   if mackerel_cfg.key?('host_status')
     host_status_cfg = mackerel_cfg['host_status']
     if host_status_cfg.key?('on_start')
-      its(:content) { should match(/^on_start = "#{host_status_cfg['on_start']}"$/).after(/^\[host_status\]/) }
+      it { should contain("on_start = \"#{e(host_status_cfg['on_start'])}\"").after(/^\[host_status\]/) }
     end
     if host_status_cfg.key?('on_stop')
-      its(:content) { should match(/^on_stop = "#{host_status_cfg['on_stop']}"$/).after(/^\[host_status\]/) }
+      it { should contain("on_stop = \"#{e(host_status_cfg['on_stop'])}\"").after(/^\[host_status\]/) }
     end
   end
   if mackerel_cfg.key?('filesystems')
     filesystems_cfg = mackerel_cfg['filesystems']
     if filesystems_cfg.key?('ignore')
-      its(:content) { should match(/^ignore = "#{filesystems_cfg['ignore']}"$/).after(/^\[filesystems\]/) }
+      it { should contain("ignore = \"#{e(filesystems_cfg['ignore'])}\"").after(/^\[filesystems\]/) }
     end
     if filesystems_cfg.key?('use_mountpoint')
-      verbose = filesystems_cfg['use_mountpoint'] ? 'true' : 'false'
-      its(:content) { should match(/^use_mountpoint = #{verbose}$/).after(/^\[filesystems\]/) }
+      use_mountpoint = filesystems_cfg['use_mountpoint'] ? 'true' : 'false'
+      it { should contain("use_mountpoint = #{use_mountpoint}").after(/^\[filesystems\]/) }
     end
   end
   if mackerel_cfg.key?('diagnostic')
     diagnostic = mackerel_cfg['diagnostic'] ? 'true' : 'false'
-    its(:content) { should match(/^diagnostic = #{diagnostic}$/) }
+    it { should contain "diagnostic = #{diagnostic}" }
   end
   if mackerel_cfg.key?('plugin')
     plugin_cfg = mackerel_cfg['plugin']
     if plugin_cfg.key?('metrics')
-      plugin_cfg['metrics'].each do |k, v|
+      plugin_cfg['metrics'].each do |_k, v|
         its(:content) { should match(/^command = "#{e(v)}"$/) }
       end
     end
-    if mackerel_cfg.key?('checkes')
-      plugin_cfg['checkes'].each do |k, v|
+    if mackerel_cfg.key?('checks')
+      plugin_cfg['checks'].each do |_k, v|
         if v.is_a?(Hash)
           its(:content) { should match(/^command = "#{e(v['command'])}"$/) }
         else

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
   template:
     src: mackerel-agent.conf.j2
     dest: /etc/mackerel-agent/mackerel-agent.conf
+    mode: "0600"
   notify: restart mackerel-agent
 - name: mackerel-agent is active and enabled on system startup service
   systemd:

--- a/templates/mackerel-agent.conf.j2
+++ b/templates/mackerel-agent.conf.j2
@@ -15,7 +15,7 @@ verbose = {{ 'true' if mackerel_agent_cfg.verbose else 'false' }}
 display_name = "{{ mackerel_agent_cfg.display_name }}"
 {% endif %}
 {% if mackerel_agent_cfg.roles is defined -%}
-roles = [ "{{ mackerel_agent_cfg.roles|join('","') }}" ]
+roles = [ "{{ mackerel_agent_cfg.roles|join('", "') }}" ]
 {% endif %}
 {% if mackerel_agent_cfg.http_proxy is defined -%}
 http_proxy = "{{ mackerel_agent_cfg.http_proxy }}"
@@ -48,38 +48,66 @@ diagnostic = {{ 'true' if mackerel_agent_cfg.diagnostic else 'false' }}
 # followings are mackerel-agent-plugins https://github.com/mackerelio/mackerel-agent-plugins
 
 {% if mackerel_agent_cfg.plugin is defined and mackerel_agent_cfg.plugin.metrics is defined -%}
-{% for key, value in mackerel_agent_cfg.plugin.metrics.items() %}
+{%   for key, value in mackerel_agent_cfg.plugin.metrics.items() %}
 [plugin.metrics.{{ key }}]
-command = "{{ value }}"
-{% endfor %}
+command = "{{ value|replace('\\', '\\\\')|replace('"', '\\"') }}"
+
+{%   endfor %}
 {% endif %}
 
 {% if mackerel_agent_cfg.plugin is defined and mackerel_agent_cfg.plugin.checks is defined -%}
-{% for key, value in mackerel_agent_cfg.plugin.checks.items() %}
+{%   for key, value in mackerel_agent_cfg.plugin.checks.items() %}
 [plugin.checks.{{ key }}]
-command = "{{ value }}"
-{% endfor %}
+{%     if value is string -%}
+command = "{{ value|replace('\\', '\\\\')|replace('"', '\\"') }}"
+{%     else -%}
+command = "{{ value.command|replace('\\', '\\\\')|replace('"', '\\"') }}"
+{%       if value.notification_interval is defined -%}
+notification_interval = {{ value.notification_interval }}
+{%       endif %}
+{%       if value.max_check_attempts is defined -%}
+max_check_attempts = {{ value.max_check_attempts }}
+{%       endif %}
+{%       if value.check_interval is defined -%}
+check_interval = {{ value.check_interval }}
+{%       endif %}
+{%       if value.timeout_seconds is defined -%}
+timeout_seconds = {{ value.timeout_seconds }}
+{%       endif %}
+{%       if value.prevent_alert_auto_close is defined -%}
+prevent_alert_auto_close = {{ 'true' if value.prevent_alert_auto_close else 'false' }}
+{%       endif %}
+{%       if value.memo is defined -%}
+memo = "{{ value.memo|replace('\\', '\\\\')|replace('"', '\\"') }}"
+{%       endif %}
+{%       if value.env is defined %}
+
+[plugin.checks.{{ key }}.env]
+{%         for env_name, env_value in value.env.items() -%}
+{{ env_name }} = "{{ env_value|replace('\\', '\\\\')|replace('"', '\\"') }}"
+{%         endfor %}
+{%       endif %}
+{%       if value.action is defined %}
+
+[plugin.checks.{{ key }}.action]
+command = "{{ value.action.command|replace('\\', '\\\\')|replace('"', '\\"') }}"
+{%         if value.action.user is defined -%}
+user = "{{ value.action.user }}"
+{%         endif %}
+{%         if value.action.env is defined %}
+
+[plugin.checks.{{ key }}.action.env]
+{%           for act_env_name, act_env_value in value.action.env.items() -%}
+{{ act_env_name }} = "{{ act_env_value|replace('\\', '\\\\')|replace('"', '\\"') }}"
+{%           endfor %}
+{%         endif %}
+{%       endif %}
+
+{%     endif %}
+
+{%   endfor %}
 {% endif %}
 
-{% if mackerel_check_plugins is defined -%}
-{% for key, value in mackerel_check_plugins.items() %}
-[plugin.checks.{{ key }}]
-{% if value is iterable -%}
-command = "{{ value.command }}"
-{% if value.notification_interval is defined -%}
-notification_interval = {{ value.notification_interval }}
-{% endif %}
-{% if value.max_check_attempts is defined -%}
-max_check_attempts = {{ value.max_check_attempts }}
-{% endif %}
-{% if value.check_interval is defined -%}
-check_interval = {{ value.check_interval }}
-{% endif %}
-{% if value.prevent_alert_auto_close is defined -%}
-prevent_alert_auto_close = {{ 'true' if value.prevent_alert_auto_close else 'false' }}
-{% endif %}
-{% else %}
-command = "{{ value }}"
-{% endif %}
-{% endfor %}
+{% if mackerel_agent_cfg.extra_setting is defined -%}
+{{ mackerel_agent_cfg.extra_setting }}
 {% endif %}


### PR DESCRIPTION
* checkプラグインのaction属性を指定できるようにしました
     * [チェック監視の結果に応じてコマンドを実行させられるようになりました　ほか](https://mackerel.io/ja/blog/entry/weekly/20171027)
     * action属性の出力方法はInline Tableで表現しきれないため、通常のTable形式で出力するようにしています。
         * [設定ファイル記述言語 TOML](https://qiita.com/b4b4r07/items/77c327742fc2256d6cbe)
* 設定ファイルのアクセス権を「0600」に設定する処理を追記しました